### PR TITLE
Add Conda environments for required packages

### DIFF
--- a/environment-cuda.yml
+++ b/environment-cuda.yml
@@ -1,0 +1,17 @@
+name: pde-learning
+channels:
+  - pytorch
+  - nvidia
+dependencies:
+  - python=3.9
+  - pytorch
+  - pytorch-cuda=11.7
+  - torchvision
+  - torchaudio
+  - ca-certificates
+  - certifi
+  - openssl
+  - jupyter
+  - scipy
+  - matplotlib
+prefix: /opt/miniconda3/envs/pde-learning

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,15 @@
+name: pde-learning
+channels:
+  - pytorch
+dependencies:
+  - python=3.9
+  - pytorch
+  - torchvision
+  - torchaudio
+  - ca-certificates
+  - certifi
+  - openssl
+  - jupyter
+  - scipy
+  - matplotlib
+prefix: /opt/miniconda3/envs/pde-learning


### PR DESCRIPTION
This PR adds `environment.yml` files for both CUDA-based setups, and non-CUDA setups (e.g. CPU, or macOS with M1 GPU accelleration). They can be imported using `conda env create --force -f [environment|environment-cuda].yml` into a new environment named `pde-learning` 👍 